### PR TITLE
Wip/concurrent safety

### DIFF
--- a/src/axios-har-tracker.ts
+++ b/src/axios-har-tracker.ts
@@ -52,6 +52,7 @@ export class AxiosHarTracker {
       }
     };
 
+    /*
     this.axios.interceptors.request.use(
       async config => {
         this.newEntry = this.generateNewEntry();
@@ -66,6 +67,7 @@ export class AxiosHarTracker {
         return Promise.reject(error);
       }
     );
+    */
 
     this.axios.interceptors.response.use(
       async resp => {
@@ -153,8 +155,10 @@ export class AxiosHarTracker {
   }
 
   private pushNewEntryResponse(response) {
-    this.newEntry.response = this.returnResponseObject(response);
-    this.generatedHar.log.entries.push(this.newEntry);
+    var newEntry = this.generateNewEntry();
+    newEntry.request = this.returnRequestObject(response.config);
+    newEntry.response = this.returnResponseObject(response);
+    this.generatedHar.log.entries.push(newEntry);
   }
 
   private generateNewEntry() {


### PR DESCRIPTION
This allows correct tracing when using with `Promise.all` or similar concurrency routines.