### PR TITLE
maxEntries support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ which will be passed into `AxiosHarTracker` constructor:
 ```js
 const axiosTracker = new AxiosHarTracker(axios);
 ```
+The constructor takes an optional second object for creator configuration and an optional third argument ```maxEntries```, which will prevent
+the log from growing beyond that size.
 
 In order to perform an actual request use the axios.get/post/delete... call, examples:
 

--- a/src/axios-har-tracker.ts
+++ b/src/axios-har-tracker.ts
@@ -42,15 +42,18 @@ export class AxiosHarTracker {
   private generatedHar: HarFile;
   private newEntry: NewEntry;
   private creatorConfig: AxiosHarTrackerCreatorConfig;
+  private maxEntries: number;
 
   constructor(
     axiosModule: AxiosInstance,
     creatorConfig: AxiosHarTrackerCreatorConfig = {
       name: "axios-har-tracker",
       version: "0.1.0",
-    }
+    },
+    maxEntries?:number
   ) {
     this.axios = axiosModule;
+    this.maxEntries = maxEntries;
     this.creatorConfig = creatorConfig;
     this.resetHar();
 
@@ -64,6 +67,7 @@ export class AxiosHarTracker {
         if (error.request) {
           this.newEntry.request = this.returnRequestObject(error.request);
           this.generatedHar.log.entries.push(this.newEntry);
+          this.pruneLog();
         }
         return Promise.reject(error);
       }
@@ -163,6 +167,13 @@ export class AxiosHarTracker {
   private pushNewEntryResponse(response) {
     this.newEntry.response = this.returnResponseObject(response);
     this.generatedHar.log.entries.push(this.newEntry);
+    this.pruneLog();
+  }
+
+  private pruneLog() {
+    if (this.maxEntries !== undefined && this.generatedHar.log.entries?.length > this.maxEntries) {
+     this.generatedHar.log.entries.shift();
+    }
   }
 
   private generateNewEntry() {


### PR DESCRIPTION
Instead of tracking the requests/responses indefinitely, limit the size of the log to maxEntries.